### PR TITLE
Accept param hash on ExploreMars.get methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.1.0
   - 2.2.2
 before_install:
-  - gem update --system
+  - gem update --system 2.4.8
 install: "bundle install"
 script: "bundle exec rake"
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,13 @@ There are only a few parts to this gem so far, so it's relatively simple
 to use. By calling:
 
 ```ruby
-ExploreMars.get_by_sol(rover, sol, camera)
+ExploreMars.get_by_sol(rover: <ROVER>, sol: <SOL>, camera: <CAMERA>)
+```
+
+For example:
+
+```ruby
+ExploreMars.get_by_sol(rover: "curiosity", sol: 1000, camera: "FHAZ")
 ```
 
 you can make a call to the API, which will return a set of ```Photos```.
@@ -75,27 +81,32 @@ sensitive. The cameras are as follows:
 You can also make the API call without providing the camera argument to receive all photos that were taken on a particular sol from all cameras:
 
 ```ruby
-ExploreMars.get_by_sol(rover, sol)
+ExploreMars.get_by_sol(rover: <ROVER>, sol: <SOL>)
 ```
 
 If you would prefer to query by a particular Earth date instead, you can use:
 
 ```ruby
-ExploreMars.get_by_date(rover, date, camera)
+ExploreMars.get_by_date(rover: <ROVER>, date: <DATE>, camera: <CAMERA>)
 ```
 
 or
 
 ```ruby
-ExploreMars.get_by_date(rover, date)
+ExploreMars.get_by_date(rover: <ROVER>, date: <DATE>)
 ```
 
 The date param should be entered as a String, formatted as "yyyy-mm-dd".
 
+For example:
 
-The ```Photo``` objects that get returned have five main attributes:
-```rover```, ```sol```, ```camera```, ```earth_date```, and ```src```.
-The ```src``` attribute contains the source url of the actual image.
+```ruby
+ExploreMars.get_by_date(rover: "curiosity", date: "2015-12-4")
+```
+
+The `Photo` objects that get returned have five main attributes:
+`rover`, `sol`, `camera`, `earth_date`, and `src`.
+The `src` attribute contains the source url of the actual image.
 In order to display an image in a Rails view for example, I could use:
 
 ```ruby

--- a/lib/explore_mars.rb
+++ b/lib/explore_mars.rb
@@ -13,8 +13,8 @@ require "explore_mars/date_query"
 
 module ExploreMars
   def self.help
-    puts "- use ExploreMars#get_by_sol(rover, sol, camera) to receive a collection of photos by sol"
-    puts "- use ExploreMars#get_by_date(rover, date, camera) to receive a collection of photos by Earth date"
+    puts "- use ExploreMars#get_by_sol(rover: <ROVER>, sol: <SOL>, camera: <CAMERA>) to receive a collection of photos by sol"
+    puts "- use ExploreMars#get_by_date(rover: <ROVER>, date: <DATE>, camera: <CAMERA>) to receive a collection of photos by Earth date"
     puts "-- rover argument should be the name of one of NASA's Mars rovers"
     puts "-- sol argument should be a number representing the Martian day on which the photo was taken"
     puts "-- date argument should be a string formmated as yyyy-mm-dd"
@@ -29,11 +29,13 @@ module ExploreMars
     puts "- ExploreMars::Photo#src will return the source url for the photo"
   end
 
-  def self.get_by_sol(rover, sol, camera=nil)
-    SolQuery.new(rover, sol, camera).get
+  def self.get_by_sol(params)
+    fail "Rover and Sol are required" if (params[:rover].blank? || params[:sol].blank?)
+    SolQuery.new(params[:rover], params[:sol], params[:camera]).get
   end
 
-  def self.get_by_date(rover, date, camera=nil)
-    DateQuery.new(rover, date, camera).get
+  def self.get_by_date(params)
+    fail "Rover and Date are required" if (params[:rover].blank? || params[:date].blank?)
+    DateQuery.new(params[:rover], params[:date], params[:camera]).get
   end
 end

--- a/lib/explore_mars/call.rb
+++ b/lib/explore_mars/call.rb
@@ -19,7 +19,7 @@ module ExploreMars
 
     def check_cameras(camera)
       if !camera.empty? && !CAMERAS.include?(camera.upcase)
-        raise "Camera argument must be one of #{CAMERAS.join(', ')}"
+        fail "Camera argument must be one of #{CAMERAS.join(', ')}"
       end
     end
   end

--- a/lib/explore_mars/version.rb
+++ b/lib/explore_mars/version.rb
@@ -1,3 +1,3 @@
 module ExploreMars
-  VERSION = "0.4.4"
+  VERSION = "0.5.1"
 end

--- a/spec/sol_query_spec.rb
+++ b/spec/sol_query_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 
 describe ExploreMars::SolQuery do
+
   describe "attributes" do
     it "should have a sol and a camera" do
       query = ExploreMars::SolQuery.new("curiosity", 940, "FHAZ")
@@ -12,14 +13,17 @@ describe ExploreMars::SolQuery do
   end
 
   describe "cameras" do
-    it "should be valid" do
+    it "handles a correct Camera" do
       expect{
         ExploreMars::SolQuery.new("curiosity", 940, "FHAZ").get
       }.not_to raise_error
+    end
 
+    it "raises an error when Camera is invalid" do
+      stub_const("CAMERAS", ["FHAZ", "RHAZ", "MAST", "CHEMCAM", "NAVCAM", "MAHLI", "MARDI", "PANCAM", "MINITES"])
       expect{
         ExploreMars::SolQuery.new("curiosity", 940, "Not a camera").get
-      }.to raise_error
+      }.to raise_error("Camera argument must be one of #{CAMERAS.join(', ')}")
     end
   end
 


### PR DESCRIPTION
A hash of parameters is now expected for `ExploreMars.get_by_sol` and `ExploreMars.get_by_date` instead of an ordered list of params.
